### PR TITLE
Fix parse error

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var pipeline = require('stream-combiner')
 
 function createParseStream() {
   var stream
-    , queued = {}
+    , queued = { keywords: { } }
     , lineNumber = -1
     , head = false
     , raw = ''

--- a/test.js
+++ b/test.js
@@ -109,3 +109,20 @@ test('file "head" included in first host raw', function(t) {
 
   stream.end(input)
 })
+
+test('parameters before a first host', function(t) {
+  var input = [
+    'ForwardAgent no'
+  , 'Host one'
+  ].join('\n')
+
+  var stream = ssh.createParseStream()
+
+  t.plan(1)
+
+  stream.once('data', function(host) {
+    t.equal(host.raw, 'ForwardAgent no\nHost one\n')
+  })
+
+  stream.end(input)
+})


### PR DESCRIPTION
I fixed that a parse error happens if parameters exists above a first host.
